### PR TITLE
Config adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Kafka Queue driver for Laravel
 5. Add LaravelQueueKafkaServiceProvider to `providers` array in `config/app.php`:
 
 	`Rapide\LaravelQueueKafka\LaravelQueueKafkaServiceProvider::class,`
+	
+   If you are using Lumen, put this in `bootstrap/app.php`
+    
+    `$app->register(Rapide\LaravelQueueKafka\LumenQueueKafkaServiceProvider::class);`
 
 6. Add these properties to `.env` with proper values:
 

--- a/src/LumenQueueKafkaServiceProvider.php
+++ b/src/LumenQueueKafkaServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rapide\LaravelQueueKafka;
+
+class LumenQueueKafkaServiceProvider extends LaravelQueueKafkaServiceProvider
+{
+    /**
+     * Register the application's event listeners.
+     */
+    public function boot()
+    {
+        parent::boot();
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/kafka.php', 'queue.connections.kafka'
+        );
+    }
+}

--- a/src/Queue/Connectors/KafkaConnector.php
+++ b/src/Queue/Connectors/KafkaConnector.php
@@ -6,9 +6,9 @@ use Illuminate\Container\Container;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Rapide\LaravelQueueKafka\Queue\KafkaQueue;
 use RdKafka\Conf;
-use RdKafka\TopicConf;
-use RdKafka\Producer;
 use RdKafka\KafkaConsumer;
+use RdKafka\Producer;
+use RdKafka\TopicConf;
 
 class KafkaConnector implements ConnectorInterface
 {

--- a/src/Queue/Connectors/KafkaConnector.php
+++ b/src/Queue/Connectors/KafkaConnector.php
@@ -6,9 +6,9 @@ use Illuminate\Container\Container;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 use Rapide\LaravelQueueKafka\Queue\KafkaQueue;
 use RdKafka\Conf;
-use RdKafka\Consumer;
-use RdKafka\Producer;
 use RdKafka\TopicConf;
+use RdKafka\Producer;
+use RdKafka\KafkaConsumer;
 
 class KafkaConnector implements ConnectorInterface
 {
@@ -42,7 +42,7 @@ class KafkaConnector implements ConnectorInterface
 
         /** @var TopicConf $topicConf */
         $topicConf = $this->container->makeWith('queue.kafka.topic_conf', []);
-        $topicConf->set('auto.offset.reset', 'smallest');
+        $topicConf->set('auto.offset.reset', 'largest');
 
         /** @var Conf $conf */
         $conf = $this->container->makeWith('queue.kafka.conf', []);
@@ -52,7 +52,7 @@ class KafkaConnector implements ConnectorInterface
         $conf->set('offset.store.method', 'broker');
         $conf->setDefaultTopicConf($topicConf);
 
-        /** @var Consumer $consumer */
+        /** @var KafkaConsumer $consumer */
         $consumer = $this->container->makeWith('queue.kafka.consumer', ['conf' => $conf]);
 
         return new KafkaQueue(


### PR DESCRIPTION
`auto.offset.reset` should be default to `largest`.
most consumers don't check duplicated jobs.
if offset is lost, `smallest` will be a disaster