### PR TITLE
Payloads: Laravel 5.7 queues compatibility?

### DIFF
--- a/src/Queue/KafkaQueue.php
+++ b/src/Queue/KafkaQueue.php
@@ -80,7 +80,7 @@ class KafkaQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
-        return $this->pushRaw($this->createPayload($job, $data), $queue, []);
+        return $this->pushRaw($this->createPayload($job, $queue, $data), $queue, []);
     }
 
     /**
@@ -98,6 +98,7 @@ class KafkaQueue extends Queue implements QueueContract
     {
         try {
             $topic = $this->getTopic($queue);
+            \Illuminate\Support\Facades\Log::debug('queue: ' . $queue);
 
             $pushRawCorrelationId = $this->getCorrelationId();
 
@@ -222,14 +223,14 @@ class KafkaQueue extends Queue implements QueueContract
      * Create a payload array from the given job and data.
      *
      * @param  string $job
-     * @param  mixed $data
      * @param  string $queue
+     * @param  mixed $data
      *
      * @return array
      */
-    protected function createPayloadArray($job, $data = '', $queue = null)
+    protected function createPayloadArray($job, $queue = null, $data = '')
     {
-        return array_merge(parent::createPayloadArray($job, $data), [
+        return array_merge(parent::createPayloadArray($job, $queue, $data), [
             'id' => $this->getCorrelationId(),
             'attempts' => 0,
         ]);

--- a/src/Queue/KafkaQueue.php
+++ b/src/Queue/KafkaQueue.php
@@ -98,7 +98,6 @@ class KafkaQueue extends Queue implements QueueContract
     {
         try {
             $topic = $this->getTopic($queue);
-            \Illuminate\Support\Facades\Log::debug('queue: ' . $queue);
 
             $pushRawCorrelationId = $this->getCorrelationId();
 


### PR DESCRIPTION
I'm using Laravel 5.7, and the methods for creating queue job payloads seem to have different parameters. I guess this is a Laravel 5.7 compatibility issue?