### PR TITLE
Fix broken RDKafka Implementation on Laravel 8.1.x

### DIFF
--- a/src/Queue/KafkaQueue.php
+++ b/src/Queue/KafkaQueue.php
@@ -153,7 +153,7 @@ class KafkaQueue extends Queue implements QueueContract
             }
 
 
-            $message = $this->queues[$queue]->consume(0, 1000);
+            $message = $this->queues[$queue]->consume(1000);
 
             if ($message === null) {
                 return null;


### PR DESCRIPTION
On Ubuntu 19.10 with following rdkafka installation the consume command is incompatable with the current implementation:
librdkafka version (runtime) => 0.11.6
librdkafka version (build) => 0.11.6.255

The consume command accepts only one parameter $timeout.


